### PR TITLE
fix: replace broken discord invite link

### DIFF
--- a/utils/dataSocial.js
+++ b/utils/dataSocial.js
@@ -18,7 +18,7 @@ export const dataSocial = [
     id: "discord",
     name: "discord",
     icon: <FaDiscord />,
-    path: "https://discord.gg/zWWdRVFNhC",
+    path: "https://discord.gg/soujunior-community-759176734460346423",
   },
   {
     id: "linkedin",

--- a/utils/dataSocial.js
+++ b/utils/dataSocial.js
@@ -18,7 +18,7 @@ export const dataSocial = [
     id: "discord",
     name: "discord",
     icon: <FaDiscord />,
-    path: "https://discord.gg/UJVf4kjz",
+    path: "https://discord.gg/zWWdRVFNhC",
   },
   {
     id: "linkedin",


### PR DESCRIPTION
Correção da Issue #88.
Foi feita a troca do link quebrado pelo link correto (o mesmo do README da página da SouJunior no github).